### PR TITLE
Fix/#40 작성 qa 수정

### DIFF
--- a/src/api/invitation/postInvitation.ts
+++ b/src/api/invitation/postInvitation.ts
@@ -14,3 +14,21 @@ export const postInvitation = async (invitationReq: FormData) => {
     return undefined;
   }
 };
+
+// 초대장 임시 저장
+export const postInvitationSave = async (invitationReq: FormData) => {
+  try {
+    for (const pair of invitationReq.entries()) {
+      console.log("form", pair[0], pair[1]);
+    }
+    const response = await api.post(
+      `/api/v1/invitation/temporary`,
+      invitationReq
+    );
+
+    return response.data;
+  } catch (e) {
+    console.log(e);
+    return undefined;
+  }
+};

--- a/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox0.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox0.svg
@@ -1,0 +1,4 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="14" cy="14" r="10" stroke="black"/>
+<circle cx="14" cy="14" r="13" stroke="#358FFE" stroke-width="2"/>
+</svg>

--- a/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox1.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox1.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="14" cy="14" r="10" fill="#FCFCFD"/>
+<circle cx="14" cy="14" r="13" stroke="#358FFE" stroke-width="2"/>
+</svg>
+

--- a/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox2.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox2.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="14" cy="14" r="10" stroke="#151516" stroke-linecap="square" stroke-dasharray="2 2"/>
+<circle cx="14" cy="14" r="13" stroke="#358FFE" stroke-width="2"/>
+</svg>
+

--- a/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox3.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox3.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="14" cy="14" r="10" fill="#FFE0D7"/>
+<circle cx="14" cy="14" r="13" stroke="#358FFE" stroke-width="2"/>
+</svg>
+

--- a/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox4.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox4.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="14" cy="14" r="10" fill="#FFF2D7"/>
+<circle cx="14" cy="14" r="13" stroke="#358FFE" stroke-width="2"/>
+</svg>
+

--- a/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox5.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox5.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="14" cy="14" r="10" fill="#D7E9FF"/>
+<circle cx="14" cy="14" r="13" stroke="#358FFE" stroke-width="2"/>
+</svg>
+

--- a/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox6.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox6.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="14" cy="14" r="10" fill="#E0D7FF"/>
+<circle cx="14" cy="14" r="13" stroke="#358FFE" stroke-width="2"/>
+</svg>
+

--- a/src/assets/icons/화면GUI_Full/2424_Default/color/box0.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Default/color/box0.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
+  <circle cx="11" cy="11" r="10" stroke="black"/>
+</svg>

--- a/src/assets/icons/화면GUI_Full/2424_Default/color/box1.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Default/color/box1.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="9.5" fill="#FCFCFD" stroke="#E1E1E2"/>
+</svg>

--- a/src/assets/icons/화면GUI_Full/2424_Default/color/box2.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Default/color/box2.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="11" cy="11" r="10" stroke="black" stroke-linecap="square" stroke-dasharray="2 2"/>
+</svg>

--- a/src/assets/icons/화면GUI_Full/2424_Default/color/box3.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Default/color/box3.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="10" fill="#FFE0D7"/>
+</svg>

--- a/src/assets/icons/화면GUI_Full/2424_Default/color/box4.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Default/color/box4.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="10" fill="#FFF2D7"/>
+</svg>

--- a/src/assets/icons/화면GUI_Full/2424_Default/color/box5.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Default/color/box5.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="10" fill="#D7E9FF"/>
+</svg>

--- a/src/assets/icons/화면GUI_Full/2424_Default/color/box6.svg
+++ b/src/assets/icons/화면GUI_Full/2424_Default/color/box6.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="10" fill="#E0D7FF"/>
+</svg>

--- a/src/components/invitationWrite/InvitationWriteBottomButton.tsx
+++ b/src/components/invitationWrite/InvitationWriteBottomButton.tsx
@@ -33,7 +33,7 @@ const InvitationWriteBottomButton = ({
           handleState={handleSurvey}
         />
       </S.LabelContainer>
-      <S.OkButton $isEnable={isSubmit} onClick={onClick}>
+      <S.OkButton $isEnable={isSubmit} onClick={onClick} disabled={!isSubmit}>
         {text}
       </S.OkButton>
     </S.Container>

--- a/src/components/invitationWrite/InvitationWriteBottomButton.tsx
+++ b/src/components/invitationWrite/InvitationWriteBottomButton.tsx
@@ -1,5 +1,6 @@
 import useInvitationStore from "@/store/invitation";
 import * as S from "@styles/invitationWrite/invitationWriteBottomButtonStyle";
+import { useState } from "react";
 import SlideButton from "../button/Btn_Boolean";
 
 const InvitationWriteBottomButton = ({
@@ -11,19 +12,26 @@ const InvitationWriteBottomButton = ({
   text: string;
   onClick: () => void;
 }) => {
-  const { setInvitation } = useInvitationStore();
+  const { invitation, setInvitation } = useInvitationStore();
+
+  const [attendanceSurveyEnabled, setAttendanceSurveyEnabled] =
+    useState<boolean>(invitation.attendanceSurveyEnabled);
 
   const handleSurvey = () => {
     setInvitation((invitation) => {
-      invitation.attendanceSurveyEnabled = !invitation.attendanceSurveyEnabled;
+      invitation.attendanceSurveyEnabled = !attendanceSurveyEnabled;
     });
+    setAttendanceSurveyEnabled(!attendanceSurveyEnabled);
   };
 
   return (
     <S.Container>
       <S.LabelContainer>
         <S.Label>참석 여부 조사</S.Label>
-        <SlideButton handleState={handleSurvey} />
+        <SlideButton
+          currentState={attendanceSurveyEnabled}
+          handleState={handleSurvey}
+        />
       </S.LabelContainer>
       <S.OkButton $isEnable={isSubmit} onClick={onClick}>
         {text}

--- a/src/components/invitationWrite/InvitationWriteComponent.tsx
+++ b/src/components/invitationWrite/InvitationWriteComponent.tsx
@@ -27,7 +27,6 @@ const InvitationWriteComponent = ({
   const [value, setValue] = useState(invitation.title);
 
   const newImages = [...images];
-  console.log(newImages);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;

--- a/src/components/invitationWrite/InvitationWriteComponent.tsx
+++ b/src/components/invitationWrite/InvitationWriteComponent.tsx
@@ -21,7 +21,7 @@ const InvitationWriteComponent = ({
 }) => {
   const { setToolBarContent } = useToolBarContext();
   const { invitation, setInvitation } = useInvitationStore();
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(invitation.title);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
@@ -31,6 +31,8 @@ const InvitationWriteComponent = ({
       prevInvitation.title = value;
     });
   };
+
+  console.log(invitation.title);
 
   // block 타입에 맞는 컴포넌트를 반환하는 함수
   const renderBlockContent = (block: any, index: number) => {

--- a/src/components/invitationWrite/InvitationWriteComponent.tsx
+++ b/src/components/invitationWrite/InvitationWriteComponent.tsx
@@ -6,6 +6,7 @@ import * as S from "@styles/invitationWrite/invitationWriteComponent";
 import { useState } from "react";
 import InvitationWriteCalendar from "./InvitationWriteCalendar";
 import InvitationWriteLocation from "./InvitationWriteLocation";
+import InvitationWriteBoxComponent from "./blocks/InvitationWriteBoxComponent";
 import InvitationWriteDividerComponent from "./blocks/InvitationWriteDividerComponent";
 import InvitationWritePhotoComponent from "./blocks/InvitationWritePhotoComponent";
 import InvitationWriteTextComponent from "./blocks/InvitationWriteTextComponent";
@@ -50,13 +51,14 @@ const InvitationWriteComponent = ({
           />
         );
       case "box":
-      // return (
-      //   <ContentTextBox
-      //     boxType={0}
-      //     title={block.title}
-      //     content={block.content}
-      //   />
-      // );
+        return (
+          <InvitationWriteBoxComponent
+            index={index}
+            setCurrentSequence={setCurrentSequence}
+            currentSequence={currentSequence}
+            block={block}
+          />
+        );
       case "photo":
         const image = newImages.shift();
 

--- a/src/components/invitationWrite/InvitationWriteComponent.tsx
+++ b/src/components/invitationWrite/InvitationWriteComponent.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import InvitationWriteCalendar from "./InvitationWriteCalendar";
 import InvitationWriteLocation from "./InvitationWriteLocation";
 import InvitationWriteDividerComponent from "./blocks/InvitationWriteDividerComponent";
+import InvitationWritePhotoComponent from "./blocks/InvitationWritePhotoComponent";
 import InvitationWriteTextComponent from "./blocks/InvitationWriteTextComponent";
 import InvitationWriteVoteComponent from "./calendar/InvitationWriteVoteComponent";
 
@@ -14,14 +15,19 @@ const InvitationWriteComponent = ({
   currentSequence,
   setCurrentSequence,
   blocks,
+  images,
 }: {
   currentSequence: number;
   setCurrentSequence: (sequence: number) => void;
   blocks: Block[];
+  images: File[];
 }) => {
   const { setToolBarContent } = useToolBarContext();
   const { invitation, setInvitation } = useInvitationStore();
   const [value, setValue] = useState(invitation.title);
+
+  const newImages = [...images];
+  console.log(newImages);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
@@ -31,8 +37,6 @@ const InvitationWriteComponent = ({
       prevInvitation.title = value;
     });
   };
-
-  console.log(invitation.title);
 
   // block 타입에 맞는 컴포넌트를 반환하는 함수
   const renderBlockContent = (block: any, index: number) => {
@@ -55,7 +59,20 @@ const InvitationWriteComponent = ({
       //   />
       // );
       case "photo":
-        return <img key={index} src={block.image} alt="첨부한 이미지" />;
+        const image = newImages.shift();
+
+        return (
+          image instanceof File && (
+            <InvitationWritePhotoComponent
+              key={index}
+              src={URL.createObjectURL(image)}
+              setCurrentSequence={setCurrentSequence}
+              block={block}
+              currentSequence={currentSequence}
+            />
+          )
+        );
+
       case "text":
         return (
           <div style={{ width: "100%" }}>

--- a/src/components/invitationWrite/InvitationWriteComponent.tsx
+++ b/src/components/invitationWrite/InvitationWriteComponent.tsx
@@ -94,7 +94,6 @@ const InvitationWriteComponent = ({
             currentSequence={currentSequence}
             setCurrentSequence={setCurrentSequence}
             block={block}
-            index={index}
           />
         );
       default:

--- a/src/components/invitationWrite/InvitationWriteComponent.tsx
+++ b/src/components/invitationWrite/InvitationWriteComponent.tsx
@@ -10,6 +10,7 @@ import InvitationWriteBoxComponent from "./blocks/InvitationWriteBoxComponent";
 import InvitationWriteDividerComponent from "./blocks/InvitationWriteDividerComponent";
 import InvitationWritePhotoComponent from "./blocks/InvitationWritePhotoComponent";
 import InvitationWriteTextComponent from "./blocks/InvitationWriteTextComponent";
+import InvitationWriteTimeTableComponent from "./blocks/InvitationWriteTimeTableComponent";
 import InvitationWriteVoteComponent from "./calendar/InvitationWriteVoteComponent";
 
 const InvitationWriteComponent = ({
@@ -87,7 +88,15 @@ const InvitationWriteComponent = ({
           </div>
         );
       case "timeTable":
-      // return <ContentTimeTable content={block.content} />;
+        return (
+          <InvitationWriteTimeTableComponent
+            key={index}
+            currentSequence={currentSequence}
+            setCurrentSequence={setCurrentSequence}
+            block={block}
+            index={index}
+          />
+        );
       default:
         return null;
     }

--- a/src/components/invitationWrite/InvitationWriteLocation.tsx
+++ b/src/components/invitationWrite/InvitationWriteLocation.tsx
@@ -13,15 +13,25 @@ import LocationMapComponent from "./location/LocationMapComponent";
 import LocationModal from "./location/LocationModal";
 
 const InvitationWriteLocation = () => {
+  const { invitation, setInvitation } = useInvitationStore();
   const [isFocused, setIsFocused] = useState<"input" | "search" | null>(null);
-  const [inputValue, setInputValue] = useState<string>("");
+  const [inputValue, setInputValue] = useState<string>(invitation.userLocation);
   const [searchInputValue, setSearchInputValue] = useState<string>("");
-  const [location, setLocation] = useState<SearchLocation | null>(null);
+
+  const locationInit = invitation.location
+    ? {
+        location: invitation.location,
+        address: invitation.address,
+        mapLink: invitation.mapLink,
+        latitude: invitation.latitude,
+        longitude: invitation.longitude,
+      }
+    : null;
+  const [location, setLocation] = useState<SearchLocation | null>(locationInit);
   const [isShowModal, setIsShowModal] = useState<boolean>(false);
   const [isShowSearchModal, setIsShowSearchModal] = useState<boolean>(false);
 
   const { selectedTool, setToolBarContent } = useToolBarContext();
-  const { setInvitation } = useInvitationStore();
   const { data, refetch } = useGetSearch(searchInputValue);
 
   const cancelInput = () => {

--- a/src/components/invitationWrite/InvitationWriteLocation.tsx
+++ b/src/components/invitationWrite/InvitationWriteLocation.tsx
@@ -71,6 +71,20 @@ const InvitationWriteLocation = () => {
     });
   };
 
+  const handleDeleteLocation = () => {
+    setLocation(null);
+    setSearchInputValue("");
+    setInputValue("");
+    setIsShowModal(false);
+    setInvitation((prevInvitation) => {
+      prevInvitation.location = "";
+      prevInvitation.latitude = 0;
+      prevInvitation.longitude = 0;
+      prevInvitation.mapLink = "";
+      prevInvitation.userLocation = "";
+    });
+  };
+
   return (
     <S.Container
       onClick={(e) => {
@@ -164,11 +178,7 @@ const InvitationWriteLocation = () => {
             rightBtnText={"삭제"}
             color={"red"}
             onLeftClick={() => setIsShowModal(false)}
-            onRightClick={() => {
-              setLocation(null);
-              setSearchInputValue("");
-              setIsShowModal(false);
-            }}
+            onRightClick={() => handleDeleteLocation()}
           />
         )}
       </S.InputContainer>

--- a/src/components/invitationWrite/InvitationWriteToolBar.tsx
+++ b/src/components/invitationWrite/InvitationWriteToolBar.tsx
@@ -1,6 +1,7 @@
 import {
   DeviderToolBarList,
   NomalToolBarList,
+  PhotoToolBarList,
   SubTextToolBarList,
   TextToolBarList,
 } from "@/constants/invitationWrite/toolBar";
@@ -17,9 +18,11 @@ import { useRef } from "react";
 const InvitationWriteToolBar = ({
   currentSequence,
   setBlocks,
+  setImages,
 }: {
   currentSequence: number;
   setBlocks: (newBlocks: Block[]) => void;
+  setImages: (newImages: File[]) => void;
 }) => {
   const {
     selectedTool,
@@ -31,13 +34,16 @@ const InvitationWriteToolBar = ({
     subToolBarContent,
   } = useToolBarContext();
 
-  const { invitation, setInvitation, addBlock } = useInvitationStore();
+  const { invitation, setInvitation, addBlock, addImage, photoImages } =
+    useInvitationStore();
   const selectedToolRef = useRef(selectedTool || undefined);
 
   const isSubToolBar = selectedTool && toolBarContent === TextToolBarList;
 
   const isArrowBar =
-    toolBarContent === TextToolBarList || toolBarContent === DeviderToolBarList;
+    toolBarContent === TextToolBarList ||
+    toolBarContent === DeviderToolBarList ||
+    toolBarContent === PhotoToolBarList;
 
   const handleSubTool = (index: number) => {
     setSubSelectedTool(index);
@@ -46,6 +52,7 @@ const InvitationWriteToolBar = ({
     }
   };
 
+  // 블럭 이동
   const moveBlock = (direction: "forward" | "backward") => {
     setInvitation((prevInvitation) => {
       const newArr = [...prevInvitation.blocks]; // 배열 복사
@@ -77,6 +84,7 @@ const InvitationWriteToolBar = ({
     }, 0);
   };
 
+  // 블럭 삭제
   const handleDeleteBlock = () => {
     setInvitation((invitation) => {
       invitation.blocks.splice(currentSequence, 1);
@@ -85,6 +93,8 @@ const InvitationWriteToolBar = ({
       setBlocks([...useInvitationStore.getState().invitation.blocks]);
     }, 0);
   };
+
+  // 기본 툴바 버튼 클릭시
   const handleToolButton = (index: number) => {
     setSelectedTool(index);
     selectedToolRef.current = toolBarContent[index];
@@ -113,8 +123,33 @@ const InvitationWriteToolBar = ({
             setBlocks([...useInvitationStore.getState().invitation.blocks]);
           }, 0);
           break;
-        // case "Image":
-        //   return <img src={block.image} alt="첨부한 이미지" />;
+        case "photo":
+          const triggerFileUpload = () => {
+            const input = document.createElement("input");
+            input.type = "file";
+            input.accept = "image/*";
+
+            // 파일이 선택되었을 때 실행되는 이벤트 핸들러
+            input.onchange = (event) => {
+              const file = (event.target as HTMLInputElement).files?.[0];
+              if (file) {
+                addImage(file); // 기존 파일 배열에 새 파일 추가
+                addBlock({
+                  sequence: invitation.blocks.length,
+                  type: "photo",
+                });
+                setTimeout(() => {
+                  setImages([...useInvitationStore.getState().photoImages]);
+                }, 0);
+              }
+            };
+            // 파일 선택 창을 열도록 클릭 트리거
+            input.click();
+          };
+          // 파일 업로드 실행
+          triggerFileUpload();
+          break;
+
         // case "Box":
         //   return (
         //     <div
@@ -139,20 +174,25 @@ const InvitationWriteToolBar = ({
     <S.Container>
       <S.ToolContainer>
         {/* "<" 구현 */}
-        {toolBarContent !== NomalToolBarList && (
-          <Arrow onClick={() => setToolBarContent(NomalToolBarList)} />
-        )}
-        {toolBarContent.map((item, index) => (
-          <S.ToolButton key={index} onClick={() => handleToolButton(index)}>
-            {selectedTool === item ? <item.activeIcon /> : <item.defaultIcon />}
-            {item.title && (
-              <S.ToolButtonText $isActive={selectedTool === item}>
-                {item.title}
-              </S.ToolButtonText>
-            )}
-          </S.ToolButton>
-        ))}
-
+        <S.ToolButtonContainer>
+          {toolBarContent !== NomalToolBarList && (
+            <Arrow onClick={() => setToolBarContent(NomalToolBarList)} />
+          )}
+          {toolBarContent.map((item, index) => (
+            <S.ToolButton key={index} onClick={() => handleToolButton(index)}>
+              {selectedTool === item ? (
+                <item.activeIcon />
+              ) : (
+                <item.defaultIcon />
+              )}
+              {item.title && (
+                <S.ToolButtonText $isActive={selectedTool === item}>
+                  {item.title}
+                </S.ToolButtonText>
+              )}
+            </S.ToolButton>
+          ))}
+        </S.ToolButtonContainer>
         {/* 블럭 이동 구현 */}
         {isArrowBar && (
           <S.ArrowContainer>

--- a/src/components/invitationWrite/InvitationWriteToolBar.tsx
+++ b/src/components/invitationWrite/InvitationWriteToolBar.tsx
@@ -34,7 +34,7 @@ const InvitationWriteToolBar = ({
     subToolBarContent,
   } = useToolBarContext();
 
-  const { invitation, setInvitation, addBlock, addImage, photoImages } =
+  const { invitation, setInvitation, addBlock, addImage } =
     useInvitationStore();
   const selectedToolRef = useRef(selectedTool || undefined);
 
@@ -86,9 +86,23 @@ const InvitationWriteToolBar = ({
 
   // 블럭 삭제
   const handleDeleteBlock = () => {
-    setInvitation((invitation) => {
-      invitation.blocks.splice(currentSequence, 1);
+    console.log("삭제 전:", invitation.blocks);
+
+    setInvitation((prevInvitation) => {
+      const updatedBlocks = prevInvitation.blocks.filter(
+        (block) => block.sequence !== currentSequence
+      );
+
+      // sequence 값 재정렬
+      const reindexedBlocks = updatedBlocks.map((block, index) => ({
+        ...block,
+        sequence: index,
+      }));
+
+      console.log("삭제 후:", reindexedBlocks);
+      prevInvitation.blocks = structuredClone(reindexedBlocks);
     });
+
     setTimeout(() => {
       setBlocks([...useInvitationStore.getState().invitation.blocks]);
     }, 0);

--- a/src/components/invitationWrite/InvitationWriteToolBar.tsx
+++ b/src/components/invitationWrite/InvitationWriteToolBar.tsx
@@ -5,6 +5,7 @@ import {
   PhotoToolBarList,
   SubTextToolBarList,
   TextToolBarList,
+  TimeTableToolBarList,
 } from "@/constants/invitationWrite/toolBar";
 import { useToolBarContext } from "@/contexts/toolBarContext";
 import useInvitationStore from "@/store/invitation";
@@ -47,7 +48,8 @@ const InvitationWriteToolBar = ({
     toolBarContent === TextToolBarList ||
     toolBarContent === DeviderToolBarList ||
     toolBarContent === PhotoToolBarList ||
-    toolBarContent === BoxToolBarList;
+    toolBarContent === BoxToolBarList ||
+    toolBarContent === TimeTableToolBarList;
 
   const handleSubTool = (index: number) => {
     setSubSelectedTool(index);
@@ -101,7 +103,12 @@ const InvitationWriteToolBar = ({
         sequence: index,
       }));
 
-      prevInvitation.blocks = structuredClone(reindexedBlocks);
+      prevInvitation.blocks = reindexedBlocks.map((block) => ({
+        ...block,
+        content: Array.isArray(block.content)
+          ? block.content.map((item) => ({ ...item }))
+          : block.content,
+      }));
     });
 
     setTimeout(() => {
@@ -178,7 +185,15 @@ const InvitationWriteToolBar = ({
           }, 0);
           break;
         case "TimeTable":
-        // return <ContentTimeTable content={block.content} />;
+          addBlock({
+            sequence: invitation.blocks.length,
+            type: "timeTable",
+            content: [],
+          });
+          setTimeout(() => {
+            setBlocks([...useInvitationStore.getState().invitation.blocks]);
+          }, 0);
+          break;
         default:
           return null;
       }

--- a/src/components/invitationWrite/InvitationWriteToolBar.tsx
+++ b/src/components/invitationWrite/InvitationWriteToolBar.tsx
@@ -1,4 +1,5 @@
 import {
+  BoxToolBarList,
   DeviderToolBarList,
   NomalToolBarList,
   PhotoToolBarList,
@@ -38,12 +39,15 @@ const InvitationWriteToolBar = ({
     useInvitationStore();
   const selectedToolRef = useRef(selectedTool || undefined);
 
-  const isSubToolBar = selectedTool && toolBarContent === TextToolBarList;
+  const isSubToolBar =
+    selectedTool &&
+    (toolBarContent === TextToolBarList || toolBarContent === BoxToolBarList);
 
   const isArrowBar =
     toolBarContent === TextToolBarList ||
     toolBarContent === DeviderToolBarList ||
-    toolBarContent === PhotoToolBarList;
+    toolBarContent === PhotoToolBarList ||
+    toolBarContent === BoxToolBarList;
 
   const handleSubTool = (index: number) => {
     setSubSelectedTool(index);
@@ -86,8 +90,6 @@ const InvitationWriteToolBar = ({
 
   // 블럭 삭제
   const handleDeleteBlock = () => {
-    console.log("삭제 전:", invitation.blocks);
-
     setInvitation((prevInvitation) => {
       const updatedBlocks = prevInvitation.blocks.filter(
         (block) => block.sequence !== currentSequence
@@ -99,7 +101,6 @@ const InvitationWriteToolBar = ({
         sequence: index,
       }));
 
-      console.log("삭제 후:", reindexedBlocks);
       prevInvitation.blocks = structuredClone(reindexedBlocks);
     });
 
@@ -164,18 +165,18 @@ const InvitationWriteToolBar = ({
           triggerFileUpload();
           break;
 
-        // case "Box":
-        //   return (
-        //     <div
-        //       style={{ width: "100%" }}
-        //       onClick={() => setCurrentSequence(block.sequence)}
-        //     >
-        //       <InvitationWriteTextComponent
-        //         currentSequence={currentSequence}
-        //         block={block}
-        //       />
-        //     </div>
-        //   );
+        case "Box":
+          addBlock({
+            sequence: invitation.blocks.length,
+            type: "box",
+            title: "",
+            colorCode: 0,
+            content: "",
+          });
+          setTimeout(() => {
+            setBlocks([...useInvitationStore.getState().invitation.blocks]);
+          }, 0);
+          break;
         case "TimeTable":
         // return <ContentTimeTable content={block.content} />;
         default:

--- a/src/components/invitationWrite/blocks/InvitationWriteBoxComponent.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWriteBoxComponent.tsx
@@ -105,7 +105,7 @@ const InvitationWriteBoxComponent = ({
         <hr />
         <S.ContentInput
           placeholder="내용을 입력하세요"
-          value={value}
+          value={typeof value === "string" ? value : undefined}
           onChange={handleInputChange}
         />
       </S.TextBoxWrap>

--- a/src/components/invitationWrite/blocks/InvitationWriteBoxComponent.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWriteBoxComponent.tsx
@@ -1,0 +1,116 @@
+import {
+  BoxToolBarList,
+  SubBoxStyleBarList,
+} from "@/constants/invitationWrite/toolBar";
+import { BoxColor } from "@/constants/invite";
+import { useToolBarContext } from "@/contexts/toolBarContext";
+import useInvitationStore from "@/store/invitation";
+import * as S from "@/styles/invitationWrite/blocks/invitationWriteBoxComponent";
+import { Block } from "@/types/invitation";
+import { useEffect, useState } from "react";
+
+type Props = {
+  currentSequence: number;
+  setCurrentSequence: (sequence: number) => void;
+  block: Block;
+  index: number;
+};
+
+const InvitationWriteBoxComponent = ({
+  currentSequence,
+  setCurrentSequence,
+  block,
+  index,
+}: Props) => {
+  const {
+    selectedTool,
+    toolBarContent,
+    subSelectedTool,
+    subToolBarContent,
+    setToolBarContent,
+    setSubToolBarContent,
+  } = useToolBarContext();
+  const [titleValue, setTitleValue] = useState(block.title || "");
+  const [value, setValue] = useState(block.content || "");
+  const [color, setColor] = useState<number>(
+    block.colorCode ? block.colorCode : 0
+  );
+
+  console.log(color);
+  const { updateBlock } = useInvitationStore();
+
+  const isFocus =
+    currentSequence === block.sequence && toolBarContent === BoxToolBarList;
+
+  useEffect(() => {
+    if (selectedTool === toolBarContent[0]) {
+      setSubToolBarContent(SubBoxStyleBarList);
+    }
+  }, [selectedTool]);
+
+  useEffect(() => {
+    if (subToolBarContent === SubBoxStyleBarList) {
+      updateBlock(currentSequence, {
+        colorCode: Number(subSelectedTool?.type),
+      });
+      if (currentSequence === index) setColor(Number(subSelectedTool?.type));
+    }
+  }, [subSelectedTool]);
+
+  const handleFocus = () => {
+    if (toolBarContent !== BoxToolBarList)
+      setTimeout(() => {
+        setToolBarContent(BoxToolBarList);
+      }, 0);
+  };
+
+  const handleTitleInputChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    const newValue = event.target.value;
+    setTitleValue(newValue);
+    updateBlock(block.sequence, { title: newValue });
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = event.target.value;
+    setValue(newValue);
+
+    event.target.style.height = "auto";
+    event.target.style.height = `${event.target.scrollHeight}px`;
+
+    updateBlock(block.sequence, { content: newValue });
+  };
+
+  return (
+    <S.InputContainer
+      $isSequence={isFocus}
+      onClick={(e) => {
+        e.stopPropagation();
+        handleFocus();
+        setCurrentSequence(block.sequence);
+      }}
+    >
+      <S.TextBoxWrap
+        style={{
+          backgroundColor: BoxColor[color].bgColor,
+          border: BoxColor[color].border,
+        }}
+      >
+        <S.TitleInput
+          placeholder="제목을 입력하세요"
+          value={titleValue}
+          onChange={handleTitleInputChange}
+        />
+        <hr />
+        <S.ContentInput
+          placeholder="내용을 입력하세요"
+          value={value}
+          onChange={handleInputChange}
+        />
+      </S.TextBoxWrap>
+    </S.InputContainer>
+  );
+};
+
+export default InvitationWriteBoxComponent;

--- a/src/components/invitationWrite/blocks/InvitationWritePhotoComponent.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWritePhotoComponent.tsx
@@ -1,0 +1,43 @@
+import { PhotoToolBarList } from "@/constants/invitationWrite/toolBar";
+import { useToolBarContext } from "@/contexts/toolBarContext";
+import { Block } from "@/types/invitation";
+import * as S from "@styles/invitationWrite/blocks/invitationWriteDividerComponentStyle";
+
+interface InvitationWritePhotoComponentProps {
+  currentSequence: number;
+  src: string;
+  setCurrentSequence: (sequence: number) => void;
+  block: Block;
+}
+
+const InvitationWritePhotoComponent: React.FC<
+  InvitationWritePhotoComponentProps
+> = ({ currentSequence, src, block, setCurrentSequence }) => {
+  const { toolBarContent, setToolBarContent } = useToolBarContext();
+
+  const isFocus =
+    currentSequence === block.sequence && toolBarContent === PhotoToolBarList;
+
+  const handleFocus = () => {
+    if (toolBarContent !== PhotoToolBarList)
+      setTimeout(() => {
+        setToolBarContent(PhotoToolBarList);
+      }, 0);
+  };
+
+  return (
+    <S.Container
+      onClick={(e) => {
+        e.stopPropagation();
+        handleFocus();
+        setCurrentSequence(block.sequence);
+      }}
+    >
+      <S.InputContainer $isSequence={isFocus}>
+        <img src={src} alt="첨부한 이미지" />
+      </S.InputContainer>
+    </S.Container>
+  );
+};
+
+export default InvitationWritePhotoComponent;

--- a/src/components/invitationWrite/blocks/InvitationWriteTextComponent.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWriteTextComponent.tsx
@@ -92,7 +92,7 @@ const InvitationWriteTextComponent: React.FC<
       }
 
       if (Object.keys(updatedProperties).length > 0) {
-        updateBlock(currentSequence, updatedProperties);
+        updateBlock(block.sequence, updatedProperties);
       }
     }
   }, [subSelectedTool, subToolBarContent, block.sequence, updateBlock]);

--- a/src/components/invitationWrite/blocks/InvitationWriteTextComponent.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWriteTextComponent.tsx
@@ -128,7 +128,7 @@ const InvitationWriteTextComponent: React.FC<
       <S.InputContainer $isSequence={isFocus}>
         <S.InputText
           placeholder="내용을 입력하세요"
-          value={value}
+          value={typeof value === "string" ? value : ""}
           onChange={handleInputChange}
           style={{
             font: `var(${font})`,
@@ -143,7 +143,7 @@ const InvitationWriteTextComponent: React.FC<
                 : "none",
           }}
         >
-          <span>{value}</span>
+          <span>{typeof value === "string" ? value : ""}</span>
         </S.InputText>
       </S.InputContainer>
     </S.Container>

--- a/src/components/invitationWrite/blocks/InvitationWriteTextComponent.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWriteTextComponent.tsx
@@ -32,10 +32,14 @@ const InvitationWriteTextComponent: React.FC<
 
   const { updateBlock } = useInvitationStore();
 
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(block.content || "");
   const [font, setFont] = useState(block.font || "");
   const [style, setStyle] = useState(block.styles || "");
   const [color, setColor] = useState(block.color || "");
+
+  useEffect(() => {
+    if (block.content) setValue(block.content);
+  }, [block]);
 
   useEffect(() => {
     if (selectedTool === toolBarContent[0]) {

--- a/src/components/invitationWrite/blocks/InvitationWriteTimeItem.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWriteTimeItem.tsx
@@ -1,0 +1,82 @@
+import useInvitationStore from "@/store/invitation";
+import { TimeTable } from "@/types/invitation";
+import { formatTimeToCustomFormat } from "@/utils/calendar/formatCustomDateFromDate";
+import ActiveTime from "@assets/icons/화면GUI_Full/2424_Activate/Time.svg?react";
+import Time from "@assets/icons/화면GUI_Full/2424_Default/Time.svg?react";
+import * as S from "@styles/invitationWrite/blocks/invitationWriteTimeItem";
+import { useState } from "react";
+import InvitationWriteTimeTableModal from "../calendar/InvitationWriteTimeTableModal";
+
+interface InvitationWriteVoteItemProps {
+  index: number;
+  item: TimeTable;
+  currentSequence: number;
+}
+
+const InvitationWriteTimeItem: React.FC<InvitationWriteVoteItemProps> = ({
+  index,
+  item,
+  currentSequence,
+}) => {
+  const [isShowModal, setIsShowModal] = useState<boolean>(false);
+  const { invitation, updateTimeTableContent } = useInvitationStore();
+  const [value, setValue] = useState(item.content ? item.content : "");
+
+  const formatTime =
+    Array.isArray(invitation.blocks[currentSequence].content) &&
+    invitation.blocks[currentSequence].content[index]?.time !== ""
+      ? formatTimeToCustomFormat(
+          invitation.blocks[currentSequence].content[index]?.time || ""
+        )
+      : "시간 선택";
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    setValue(newValue);
+
+    updateTimeTableContent(currentSequence, index, value);
+  };
+
+  return (
+    <S.DateContainer>
+      <S.ComponentContainer>
+        <S.ButtonContainer>
+          <S.SelectTimeButton onClick={() => setIsShowModal(!isShowModal)}>
+            {formatTime === "시간 선택" ? (
+              <>
+                <Time />
+                <S.ButtonText>{formatTime}</S.ButtonText>
+              </>
+            ) : (
+              <>
+                <ActiveTime />
+                <S.ButtonText style={{ color: "var(--Black)" }}>
+                  {formatTime}
+                </S.ButtonText>
+              </>
+            )}
+          </S.SelectTimeButton>
+
+          <S.TimeInput
+            placeholder="내용을 입력하세요"
+            value={value}
+            onChange={handleInputChange}
+          />
+
+          {isShowModal && (
+            <InvitationWriteTimeTableModal
+              handleCloseModal={() => setIsShowModal(false)}
+              index={index}
+              item={item}
+              currentSequence={currentSequence}
+            />
+          )}
+        </S.ButtonContainer>
+
+        {/* Modal */}
+      </S.ComponentContainer>
+    </S.DateContainer>
+  );
+};
+
+export default InvitationWriteTimeItem;

--- a/src/components/invitationWrite/blocks/InvitationWriteTimeTableComponent.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWriteTimeTableComponent.tsx
@@ -10,20 +10,12 @@ interface InvitationWriteTextComponentProps {
   currentSequence: number;
   block: Block;
   setCurrentSequence: (sequence: number) => void;
-  index: number;
 }
 
 const InvitationWriteTimeTableComponent: React.FC<
   InvitationWriteTextComponentProps
-> = ({ currentSequence, block, setCurrentSequence, index }) => {
-  const {
-    selectedTool,
-    subSelectedTool,
-    toolBarContent,
-    subToolBarContent,
-    setToolBarContent,
-    setSubToolBarContent,
-  } = useToolBarContext();
+> = ({ currentSequence, block, setCurrentSequence }) => {
+  const { toolBarContent, setToolBarContent } = useToolBarContext();
 
   const { updateBlock } = useInvitationStore();
 

--- a/src/components/invitationWrite/blocks/InvitationWriteTimeTableComponent.tsx
+++ b/src/components/invitationWrite/blocks/InvitationWriteTimeTableComponent.tsx
@@ -1,0 +1,76 @@
+import { TimeTableToolBarList } from "@/constants/invitationWrite/toolBar";
+import { useToolBarContext } from "@/contexts/toolBarContext";
+import useInvitationStore from "@/store/invitation";
+import { Block } from "@/types/invitation";
+import Add from "@assets/icons/화면GUI_Line/2020/Add_White.svg?react";
+import * as S from "@styles/invitationWrite/blocks/invitationWriteTimeTableComponent";
+import InvitationWriteTimeItem from "./InvitationWriteTimeItem";
+
+interface InvitationWriteTextComponentProps {
+  currentSequence: number;
+  block: Block;
+  setCurrentSequence: (sequence: number) => void;
+  index: number;
+}
+
+const InvitationWriteTimeTableComponent: React.FC<
+  InvitationWriteTextComponentProps
+> = ({ currentSequence, block, setCurrentSequence, index }) => {
+  const {
+    selectedTool,
+    subSelectedTool,
+    toolBarContent,
+    subToolBarContent,
+    setToolBarContent,
+    setSubToolBarContent,
+  } = useToolBarContext();
+
+  const { updateBlock } = useInvitationStore();
+
+  const handleFocus = () => {
+    if (toolBarContent !== TimeTableToolBarList)
+      setTimeout(() => {
+        setToolBarContent(TimeTableToolBarList);
+      }, 0);
+  };
+
+  const handleNewTime = () => {
+    updateBlock(block.sequence, {
+      content: Array.isArray(block.content)
+        ? [...block.content, { time: "", content: "" }]
+        : [{ time: "", content: "" }],
+    });
+  };
+
+  const isFocus =
+    currentSequence === block.sequence &&
+    toolBarContent === TimeTableToolBarList;
+
+  return (
+    <S.InputContainer $isSequence={isFocus}>
+      <S.Container
+        onClick={(e) => {
+          e.stopPropagation();
+          handleFocus();
+          setCurrentSequence(block.sequence);
+        }}
+      >
+        <label>타임테이블</label>
+        {Array.isArray(block.content) &&
+          block.content.map((item, index) => (
+            <InvitationWriteTimeItem
+              index={index}
+              item={item}
+              currentSequence={currentSequence}
+            />
+          ))}
+        <S.AddButton onClick={handleNewTime}>
+          <Add />
+          추가
+        </S.AddButton>
+      </S.Container>
+    </S.InputContainer>
+  );
+};
+
+export default InvitationWriteTimeTableComponent;

--- a/src/components/invitationWrite/calendar/InvitationWriteTimeTableModal.tsx
+++ b/src/components/invitationWrite/calendar/InvitationWriteTimeTableModal.tsx
@@ -1,0 +1,82 @@
+import useInvitationStore from "@/store/invitation";
+import { TimeTable } from "@/types/invitation";
+import { formatTimeToAM } from "@/utils/calendar/formatCustomDateFromDate";
+import ArrowDown from "@assets/icons/화면GUI_Line/2020/Arrow_Down.svg?react";
+import ArrowTop from "@assets/icons/화면GUI_Line/2020/Arrow_Top.svg?react";
+import * as S from "@styles/invitationWrite/invitationWriteTimeModal";
+import { useState } from "react";
+
+interface InvitationWriteTimeTableModalProps {
+  handleCloseModal: () => void;
+  index: number;
+  item: TimeTable;
+  currentSequence: number;
+}
+
+const InvitationWriteTimeTableModal: React.FC<
+  InvitationWriteTimeTableModalProps
+> = ({ handleCloseModal, index, item, currentSequence }) => {
+  const { updateTimeTable } = useInvitationStore();
+
+  const [hour, setHour] = useState<number>(
+    item.time === "" ? 0 : formatTimeToAM(item.time)
+  );
+  const [minute, setMinute] = useState<number>(
+    item.time === "" ? 0 : Number(item.time.split(":")[1])
+  );
+  const [isAM, setIsAM] = useState<boolean>(
+    Number(item.time.split(":")[0]) < 12
+  );
+
+  const handleDateChange = () => {
+    const newHour = isAM ? hour : hour + 12;
+    const newMinute = minute < 10 ? "0" + minute : minute;
+    const newStartTime = newHour + ":" + newMinute;
+
+    updateTimeTable(currentSequence, index, newStartTime);
+
+    handleCloseModal();
+  };
+
+  const handleTimeChange = (
+    type: "hour" | "minute" | "amPm",
+    state?: "up" | "down"
+  ) => {
+    if (type === "hour") {
+      if (state === "up" && hour < 12) setHour(hour + 1);
+      if (state === "down" && hour > 0) setHour(hour - 1);
+    } else if (type === "minute") {
+      if (state === "up" && minute < 50) setMinute(minute + 10);
+      if (state === "down" && minute > 0) setMinute(minute - 10);
+    } else if (type === "amPm") {
+      setIsAM(!isAM);
+    }
+  };
+
+  return (
+    <S.Container>
+      <S.TimeContainer>
+        <S.Time>
+          <ArrowTop onClick={() => handleTimeChange("hour", "up")} />
+          {hour}
+          <ArrowDown onClick={() => handleTimeChange("hour", "down")} />
+        </S.Time>
+        :
+        <S.Time>
+          <ArrowTop onClick={() => handleTimeChange("minute", "up")} />
+          {minute < 10 ? "0" + minute : minute}
+          <ArrowDown onClick={() => handleTimeChange("minute", "down")} />
+        </S.Time>
+        <div />
+        <S.Time>
+          <ArrowTop onClick={() => handleTimeChange("amPm")} />
+          {isAM ? "AM" : "PM"}
+          <ArrowDown onClick={() => handleTimeChange("amPm")} />
+        </S.Time>
+      </S.TimeContainer>
+      <S.OkButton onClick={() => handleDateChange()}>완료</S.OkButton>
+    </S.Container>
+  );
+};
+
+export default InvitationWriteTimeTableModal;

--- a/src/components/invitationWrite/calendar/InvitationWriteVoteComponent.tsx
+++ b/src/components/invitationWrite/calendar/InvitationWriteVoteComponent.tsx
@@ -8,7 +8,7 @@ import InvitationWriteVoteItem from "./InvitationWriteVoteItem";
 
 const InvitationWriteVoteComponent = () => {
   const { invitation, setInvitation } = useInvitationStore();
-  const [isMultiple, setIsMultiple] = useState(false);
+  const [isMultiple, setIsMultiple] = useState(invitation.scheduleVoteMultiple);
   const [currentIndex, setCurrentIndex] = useState<number | null>(null);
 
   const handleNewVote = () => {
@@ -31,11 +31,10 @@ const InvitationWriteVoteComponent = () => {
   };
 
   const handleSetMultiple = () => {
-    setIsMultiple(!isMultiple);
-
     setInvitation((invitation) => {
-      invitation.scheduleVoteMultiple = isMultiple;
+      invitation.scheduleVoteMultiple = !isMultiple;
     });
+    setIsMultiple(!isMultiple);
   };
 
   return (

--- a/src/components/invite/CheckContentWrap.tsx
+++ b/src/components/invite/CheckContentWrap.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import LocationMapComponent from "../invitationWrite/location/LocationMapComponent";
 import CheckVoteBox from "./CheckVoteBox";
 import ContentTextBox from "./ContentTextBox";
+import ContentTimeTable from "./ContentTimeTable";
 import PageFoldBtn from "./PageFoldBtn";
 
 interface Props {
@@ -85,7 +86,9 @@ const CheckContentWrap = ({ data }: Props) => {
                   <ContentTextBox
                     boxType={0}
                     title={block.title!}
-                    content={block.content!}
+                    content={
+                      typeof block.content! === "string" ? block.content : ""
+                    }
                   />
                 )}
                 {block.type === "photo" && (
@@ -107,12 +110,14 @@ const CheckContentWrap = ({ data }: Props) => {
                           : "none",
                     }}
                   >
-                    {block.content}
+                    {typeof block.content! === "string" ? block.content : ""}
                   </div>
                 )}
-                {/* {block.type === "timeTable" && (
-                  <ContentTimeTable content={block.content} />
-                )} */}
+                {block.type === "timeTable" && (
+                  <ContentTimeTable
+                    content={Array.isArray(block.content) ? block.content : []}
+                  />
+                )}
               </S.FlodItem>
             );
           })}

--- a/src/components/modal/CheckModal.tsx
+++ b/src/components/modal/CheckModal.tsx
@@ -1,0 +1,18 @@
+import SaveBox from "@assets/icons/화면GUI_Full/2424_Activate/SaveBox.svg?react";
+import * as S from "@styles/common/checkModal";
+
+interface CheckModalProps {
+  exitModal: () => void;
+}
+const CheckModal: React.FC<CheckModalProps> = ({ exitModal }) => {
+  return (
+    <S.Overlay onClick={exitModal}>
+      <S.Modal>
+        <SaveBox />
+        <h4>나의 초대장에 저장되었습니다!</h4>
+      </S.Modal>
+    </S.Overlay>
+  );
+};
+
+export default CheckModal;

--- a/src/constants/invitationWrite/toolBar.tsx
+++ b/src/constants/invitationWrite/toolBar.tsx
@@ -171,6 +171,15 @@ export const BoxToolBarList: toolBarIconListType[] = [
   },
 ];
 
+export const TimeTableToolBarList: toolBarIconListType[] = [
+  {
+    type: "timeTable",
+    defaultIcon: TimeTable,
+    activeIcon: ActiveTimeTable,
+    title: "타임테이블",
+  },
+];
+
 // SubToolBarList
 export const SubTextToolBarList: toolBarIconListType[] = [
   {

--- a/src/constants/invitationWrite/toolBar.tsx
+++ b/src/constants/invitationWrite/toolBar.tsx
@@ -16,6 +16,14 @@ import ActiveText from "@assets/icons/화면GUI_Full/2424_Activate/Text.svg?reac
 import ActiveTimeTable from "@assets/icons/화면GUI_Full/2424_Activate/Timetable.svg?react";
 import ActiveU from "@assets/icons/화면GUI_Full/2424_Activate/U.svg?react";
 import ActiveVote from "@assets/icons/화면GUI_Full/2424_Activate/Vote.svg?react";
+import ActiveBox0 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox0.svg?react";
+import ActiveBox1 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox1.svg?react";
+import ActiveBox2 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox2.svg?react";
+import ActiveBox3 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox3.svg?react";
+import ActiveBox4 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox4.svg?react";
+import ActiveBox5 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox5.svg?react";
+import ActiveBox6 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveBox6.svg?react";
+
 import ActiveColor2 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveColor2.svg?react";
 import ActiveColor3 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveColor3.svg?react";
 import ActiveColor4 from "@assets/icons/화면GUI_Full/2424_Activate/color/ActiveColor4.svg?react";
@@ -45,6 +53,13 @@ import Color5 from "@assets/icons/화면GUI_Full/2424_Default/color/Btn_pTB_Item
 import Color6 from "@assets/icons/화면GUI_Full/2424_Default/color/Btn_pTB_Item_Color 06.svg?react";
 import Color7 from "@assets/icons/화면GUI_Full/2424_Default/color/Btn_pTB_Item_Color 07.svg?react";
 import Color8 from "@assets/icons/화면GUI_Full/2424_Default/color/Btn_pTB_Item_Color 08.svg?react";
+import Box0 from "@assets/icons/화면GUI_Full/2424_Default/color/box0.svg?react";
+import Box1 from "@assets/icons/화면GUI_Full/2424_Default/color/box1.svg?react";
+import Box2 from "@assets/icons/화면GUI_Full/2424_Default/color/box2.svg?react";
+import Box3 from "@assets/icons/화면GUI_Full/2424_Default/color/box3.svg?react";
+import Box4 from "@assets/icons/화면GUI_Full/2424_Default/color/box4.svg?react";
+import Box5 from "@assets/icons/화면GUI_Full/2424_Default/color/box5.svg?react";
+import Box6 from "@assets/icons/화면GUI_Full/2424_Default/color/box6.svg?react";
 import Godic from "@assets/icons/화면GUI_Full/2424_Default/godic.svg?react";
 import Serif from "@assets/icons/화면GUI_Full/2424_Default/serif.svg?react";
 import ArrowBottom from "@assets/icons/화면GUI_Full/3232/Arrow_Bottom.svg?react";
@@ -147,6 +162,15 @@ export const PhotoToolBarList: toolBarIconListType[] = [
   },
 ];
 
+export const BoxToolBarList: toolBarIconListType[] = [
+  {
+    type: "box",
+    defaultIcon: Box,
+    activeIcon: ActiveBox,
+    title: "박스",
+  },
+];
+
 // SubToolBarList
 export const SubTextToolBarList: toolBarIconListType[] = [
   {
@@ -224,6 +248,44 @@ export const SubColorStyleBarList: toolBarIconListType[] = [
     type: "color8",
     defaultIcon: Color8,
     activeIcon: ActiveColor8,
+  },
+];
+
+export const SubBoxStyleBarList: toolBarIconListType[] = [
+  {
+    type: "0",
+    defaultIcon: Box0,
+    activeIcon: ActiveBox0,
+  },
+  {
+    type: "1",
+    defaultIcon: Box1,
+    activeIcon: ActiveBox1,
+  },
+  {
+    type: "2",
+    defaultIcon: Box2,
+    activeIcon: ActiveBox2,
+  },
+  {
+    type: "3",
+    defaultIcon: Box3,
+    activeIcon: ActiveBox3,
+  },
+  {
+    type: "4",
+    defaultIcon: Box4,
+    activeIcon: ActiveBox4,
+  },
+  {
+    type: "5",
+    defaultIcon: Box5,
+    activeIcon: ActiveBox5,
+  },
+  {
+    type: "6",
+    defaultIcon: Box6,
+    activeIcon: ActiveBox6,
   },
 ];
 

--- a/src/constants/invitationWrite/toolBar.tsx
+++ b/src/constants/invitationWrite/toolBar.tsx
@@ -63,7 +63,7 @@ export const NomalToolBarList: toolBarIconListType[] = [
     activeIcon: ActiveLine,
   },
   {
-    type: "Image",
+    type: "photo",
     defaultIcon: Image,
     activeIcon: ActiveImage,
     title: "사진",
@@ -135,6 +135,15 @@ export const DeviderToolBarList: toolBarIconListType[] = [
     type: "devider",
     defaultIcon: Line,
     activeIcon: ActiveLine,
+  },
+];
+
+export const PhotoToolBarList: toolBarIconListType[] = [
+  {
+    type: "photo",
+    defaultIcon: Image,
+    activeIcon: ActiveImage,
+    title: "사진",
   },
 ];
 

--- a/src/hooks/write/usePostInvitation.ts
+++ b/src/hooks/write/usePostInvitation.ts
@@ -1,9 +1,18 @@
-import { postInvitation } from "@/api/invitation/postInvitation";
+import {
+  postInvitation,
+  postInvitationSave,
+} from "@/api/invitation/postInvitation";
 import { InvitationResponse } from "@/types/invitation";
 import { useMutation } from "@tanstack/react-query";
 
 export function usePostInvitation() {
   return useMutation<InvitationResponse, Error, FormData>({
     mutationFn: (invitationReq) => postInvitation(invitationReq),
+  });
+}
+
+export function usePostInvitationSave() {
+  return useMutation<InvitationResponse, Error, FormData>({
+    mutationFn: (invitationReq) => postInvitationSave(invitationReq),
   });
 }

--- a/src/pages/InvitationWritePage.tsx
+++ b/src/pages/InvitationWritePage.tsx
@@ -15,6 +15,9 @@ const InvitationWritePage = () => {
   const [isButtonEnable] = useState<boolean>(false);
   const blocksRef = useRef(invitation.blocks || undefined);
   const [blocks, setBlocks] = useState(invitation.blocks || undefined);
+  const imagesRef = useRef(photoImages || undefined);
+  const [images, setImages] = useState(photoImages || undefined);
+
   const [currentSequence, setCurrentSequence] = useState(0);
   const [isCheckComponent, setIsCheckComponent] = useState(false);
   // const [isSubmit, setIsSubmit] = useState<boolean>(false);
@@ -24,9 +27,17 @@ const InvitationWritePage = () => {
     blocksRef.current = newBlocks;
   };
 
+  const setImagesRef = (newImages: typeof photoImages) => {
+    imagesRef.current = newImages;
+  };
+
   useEffect(() => {
     setBlocks([...invitation.blocks]);
   }, [invitation.blocks]);
+
+  useEffect(() => {
+    setImages([...photoImages]);
+  }, [photoImages]);
 
   return (
     <ToolBarProvider>
@@ -42,11 +53,13 @@ const InvitationWritePage = () => {
             <InvitationWriteToolBar
               currentSequence={currentSequence}
               setBlocks={setBlocksRef}
+              setImages={setImagesRef}
             />
             <InvitationWriteComponent
               currentSequence={currentSequence}
               setCurrentSequence={setCurrentSequence}
               blocks={blocks}
+              images={images}
             />
             <InvitationWriteBottomButton
               isSubmit={true}

--- a/src/pages/InvitationWritePage.tsx
+++ b/src/pages/InvitationWritePage.tsx
@@ -33,7 +33,7 @@ const InvitationWritePage = () => {
 
   useEffect(() => {
     setBlocks([...invitation.blocks]);
-    console.log("----------------- Block Updated ----------------");
+    console.log(blocks);
   }, [invitation.blocks]);
 
   useEffect(() => {

--- a/src/pages/InvitationWritePage.tsx
+++ b/src/pages/InvitationWritePage.tsx
@@ -33,6 +33,7 @@ const InvitationWritePage = () => {
 
   useEffect(() => {
     setBlocks([...invitation.blocks]);
+    console.log("----------------- Block Updated ----------------");
   }, [invitation.blocks]);
 
   useEffect(() => {

--- a/src/pages/InvitationWritePage.tsx
+++ b/src/pages/InvitationWritePage.tsx
@@ -24,7 +24,7 @@ const InvitationWritePage = () => {
 
   const isSubmit =
     (invitation.location !== "" || invitation.userLocation !== "") &&
-    invitation.startDate !== "";
+    (invitation.startDate !== "" || invitation.voteDeadline !== "");
 
   const setBlocksRef = (newBlocks: typeof invitation.blocks) => {
     blocksRef.current = newBlocks;
@@ -43,6 +43,8 @@ const InvitationWritePage = () => {
     setImages([...photoImages]);
   }, [photoImages]);
 
+  const handleSave = () => {};
+
   return (
     <ToolBarProvider>
       <S.Container>
@@ -53,6 +55,7 @@ const InvitationWritePage = () => {
               buttonType={"저장"}
               isEnable={isSubmit}
               onLeftBtnClick={() => navigate("/choicecard")}
+              onRightBtnClick={() => handleSave()}
             />
             <InvitationWriteToolBar
               currentSequence={currentSequence}
@@ -66,7 +69,7 @@ const InvitationWritePage = () => {
               images={images}
             />
             <InvitationWriteBottomButton
-              isSubmit={true}
+              isSubmit={isSubmit}
               text={"다음"}
               onClick={() => setIsCheckComponent(true)}
             />

--- a/src/pages/InvitationWritePage.tsx
+++ b/src/pages/InvitationWritePage.tsx
@@ -12,7 +12,6 @@ import { useNavigate } from "react-router-dom";
 const InvitationWritePage = () => {
   const { invitation, cardImage, photoImages } = useInvitationStore();
 
-  const [isButtonEnable] = useState<boolean>(false);
   const blocksRef = useRef(invitation.blocks || undefined);
   const [blocks, setBlocks] = useState(invitation.blocks || undefined);
   const imagesRef = useRef(photoImages || undefined);
@@ -22,6 +21,10 @@ const InvitationWritePage = () => {
   const [isCheckComponent, setIsCheckComponent] = useState(false);
   // const [isSubmit, setIsSubmit] = useState<boolean>(false);
   const navigate = useNavigate();
+
+  const isSubmit =
+    (invitation.location !== "" || invitation.userLocation !== "") &&
+    invitation.startDate !== "";
 
   const setBlocksRef = (newBlocks: typeof invitation.blocks) => {
     blocksRef.current = newBlocks;
@@ -48,7 +51,7 @@ const InvitationWritePage = () => {
             <InvitationWriteHeader
               backText={"카드 선택"}
               buttonType={"저장"}
-              isEnable={isButtonEnable}
+              isEnable={isSubmit}
               onLeftBtnClick={() => navigate("/choicecard")}
             />
             <InvitationWriteToolBar

--- a/src/store/invitation.ts
+++ b/src/store/invitation.ts
@@ -51,6 +51,8 @@ const initialState: InvitationState = {
   addImage: () => {},
   addBlock: () => {},
   updateBlock: () => {},
+  updateTimeTable: () => {},
+  updateTimeTableContent: () => {},
 };
 
 const useInvitationStore = create<InvitationState>()(
@@ -84,6 +86,41 @@ const useInvitationStore = create<InvitationState>()(
         });
 
         state.invitation.blocks = updatedBlocks;
+      }),
+    updateTimeTable: (sequence: number, index: number, newTime: string) =>
+      set((state) => {
+        state.invitation.blocks = state.invitation.blocks.map((block) =>
+          block.sequence === sequence
+            ? {
+                ...block,
+                content: Array.isArray(block.content)
+                  ? block.content.map((item, i) =>
+                      i === index ? { ...item, time: newTime } : item
+                    )
+                  : block.content,
+              }
+            : block
+        );
+      }),
+    updateTimeTableContent: (
+      sequence: number,
+      index: number,
+      newContent: string
+    ) =>
+      set((state) => {
+        state.invitation.blocks = state.invitation.blocks.map((block) => {
+          if (block.sequence === sequence) {
+            return {
+              ...block,
+              content: Array.isArray(block.content)
+                ? block.content.map((item, i) =>
+                    i === index ? { ...item, content: newContent } : item
+                  )
+                : block.content,
+            };
+          }
+          return block;
+        });
       }),
   }))
 );

--- a/src/store/invitation.ts
+++ b/src/store/invitation.ts
@@ -48,7 +48,7 @@ const initialState: InvitationState = {
   photoImages: [],
   setInvitation: () => {}, // 초기 빈 함수
   setCardImage: () => {}, // 초기 빈 함수
-  setPhotoImages: () => {},
+  addImage: () => {},
   addBlock: () => {},
   updateBlock: () => {},
 };
@@ -66,9 +66,9 @@ const useInvitationStore = create<InvitationState>()(
         const { setSelectedImage } = useChoiceStore.getState(); // useChoiceStore의 상태 업데이트
         setSelectedImage(image); // 전역 상태에서 선택된 이미지를 설정
       }),
-    setPhotoImages: (images: File[]) =>
+    addImage: (image: File) =>
       set((state) => {
-        state.photoImages = images; // images를 File[] 타입으로 처리
+        state.photoImages.push(image);
       }),
     addBlock: (newBlock: Block) =>
       set((state) => {

--- a/src/store/invitation.ts
+++ b/src/store/invitation.ts
@@ -84,7 +84,6 @@ const useInvitationStore = create<InvitationState>()(
         });
 
         state.invitation.blocks = updatedBlocks;
-        console.log(state.invitation.blocks);
       }),
   }))
 );

--- a/src/styles/common/checkModal.ts
+++ b/src/styles/common/checkModal.ts
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+export const Modal = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  padding: 40px 20px;
+  background-color: var(--White);
+  border-radius: 8px;
+  width: 350px;
+
+  > h4 {
+    font: var(--RegularContext);
+    color: var(--Black);
+    text-align: center;
+  }
+`;
+
+export const Title = styled.div`
+  font: var(--BoldProperty-rNBRight);
+  color: var(--Black);
+  margin: 0 0 15px 0;
+`;
+
+export const BtnWrap = styled.div`
+  display: flex;
+  gap: 12px;
+`;

--- a/src/styles/invitationWrite/blocks/invitationWriteBoxComponent.ts
+++ b/src/styles/invitationWrite/blocks/invitationWriteBoxComponent.ts
@@ -1,0 +1,134 @@
+import { isDesktop, isTablet } from "@/hooks/Media";
+import styled from "styled-components";
+
+export const TextBoxWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  border-radius: 8px;
+  padding: 20px;
+  gap: 12px;
+  width: 100%;
+
+  > h3 {
+    font: var(--Selected-BtnName-FileName);
+    color: var(--Black);
+  }
+
+  > hr {
+    border: 1px solid var(--Gray10);
+  }
+
+  > p {
+    font: var(--RegularContext);
+    color: var(--Gray40);
+    white-space: pre-wrap;
+  }
+`;
+
+export const TitleInput = styled.textarea`
+  display: flex;
+  height: 16px;
+  color: var(--Black, #151516);
+  text-align: center;
+  width: 100%;
+  border: none;
+  resize: none;
+  box-sizing: border-box;
+  background-color: transparent;
+  font: var(--Selected-BtnName-FileName);
+
+  &:focus {
+    outline: none;
+  }
+
+  &::placeholder {
+    color: var(--Black, #151516);
+  }
+`;
+
+export const ContentInput = styled.textarea`
+  display: flex;
+  color: var(--Black, #151516);
+  text-align: center;
+  width: 100%;
+  border: none;
+  resize: none;
+  padding: 12px 4px;
+  box-sizing: border-box;
+  background-color: transparent;
+
+  &:focus {
+    outline: none;
+    /* border-radius: 4px;
+    border: 2px solid var(--Primary, #358ffe); */
+  }
+
+  &::placeholder {
+    color: var(--Gray10);
+  }
+`;
+
+export const InputContainer = styled.div<{ $isSequence: boolean }>`
+  display: flex;
+  width: 100%;
+  padding: 8px;
+
+  ${({ $isSequence }) =>
+    $isSequence &&
+    `
+      outline: none;
+      border-radius: 4px;
+      border: 2px solid var(--Primary, #358ffe);
+    `}
+`;
+
+// ------------ Time Table
+
+export const TimeTableWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  border-radius: 8px;
+  padding: 20px;
+  gap: 12px;
+  width: 100%;
+  background-color: var(--Grey5);
+
+  > h4 {
+    font: var(--Selected-BtnName-FileName);
+    color: var(-Black);
+  }
+`;
+
+export const TimeTableItem = styled.div`
+  display: flex;
+  gap: 4px;
+
+  > div {
+    background-color: var(--White);
+    border: 2px solid var(--Gray10);
+    border-radius: 4px;
+    padding: 14px 10px;
+
+    font: var(--Unselected-Field-rNBLeft);
+    color: var(--Black);
+  }
+
+  .time {
+    width: 128px;
+
+    ${isTablet} {
+      width: 160px;
+    }
+
+    ${isDesktop} {
+      width: 200px;
+    }
+  }
+
+  .content {
+    flex: 1;
+    text-align: left;
+  }
+`;

--- a/src/styles/invitationWrite/blocks/invitationWriteDividerComponentStyle.ts
+++ b/src/styles/invitationWrite/blocks/invitationWriteDividerComponentStyle.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 export const Container = styled.div`
   display: flex;
-  width: 100%;
+  width: auto;
 `;
 
 export const InputContainer = styled.div<{ $isSequence: boolean }>`
@@ -31,5 +31,12 @@ export const InputContainer = styled.div<{ $isSequence: boolean }>`
     ${isDesktop} {
       margin: 10px 160px;
     }
+  }
+
+  > img {
+    width: 100%;
+    max-width: 400px;
+    height: auto;
+    object-fit: contain;
   }
 `;

--- a/src/styles/invitationWrite/blocks/invitationWriteTimeItem.ts
+++ b/src/styles/invitationWrite/blocks/invitationWriteTimeItem.ts
@@ -1,0 +1,164 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  padding: 20px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 12px;
+  border-radius: 8px;
+  background: var(--Blue5, #eaf0f7);
+`;
+
+export const TitleContainer = styled.div`
+  display: flex;
+  width: 100%;
+  height: fit-content;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const Label = styled.p`
+  font: var(--Selected-BtnName-FileName);
+  color: var(--Black);
+  margin: 0;
+`;
+
+export const Text = styled.p`
+  font: var(--AdditionalText);
+  color: var(--Black);
+  margin: 0;
+`;
+
+export const SlideButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const DateContainer = styled.div`
+  gap: 4px;
+  align-items: center;
+  width: 100%;
+`;
+
+export const ComponentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  height: fit-content;
+  width: 100%;
+  position: relative;
+`;
+
+export const SelectDateButton = styled.button`
+  display: flex;
+  height: 48px;
+  width: 100%;
+  padding: 12px;
+  align-items: center;
+  gap: 8px;
+  border-radius: 4px;
+  border: 2px solid var(--Blue-10, #d7e9ff);
+  background: var(--White, #fcfcfd);
+  cursor: pointer;
+`;
+
+export const ButtonText = styled.p`
+  font: var(--Unselected-Field-rNBLeft);
+  color: var(--Gray40);
+`;
+
+export const SelectTimeButton = styled.button`
+  display: flex;
+  height: 48px;
+  padding: 12px;
+  min-width: 128px;
+  align-items: center;
+  gap: 8px;
+  border-radius: 4px;
+  border: 2px solid var(--Gray10, #e1e1e2);
+  background: var(--White, #fcfcfd);
+  cursor: pointer;
+`;
+
+export const TimeInput = styled.input`
+  display: flex;
+  height: 48px;
+  padding: 12px;
+  align-items: center;
+  gap: 12px;
+  border-radius: 4px;
+  border: 2px solid var(--Grey-10, #e1e1e2);
+  background: var(--White, #fcfcfd);
+  box-sizing: border-box;
+  width: 100%;
+
+  &::placeholder {
+    color: var(--Grey40, #88898a);
+    font: var(--Unselected-Field-rNBLeft);
+  }
+
+  &:focus {
+    outline: none;
+    border: 2px solid var(--Primary, #358ffe);
+  }
+`;
+
+export const ItemContainer = styled.div<{ isSelected?: boolean }>`
+  display: flex;
+  align-items: center;
+  height: fit-content;
+  width: 100%;
+  padding: 8px 4px;
+  margin-bottom: 4px;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  background-color: ${({ isSelected }) =>
+    isSelected ? "var(--Blue10)" : "transparent"};
+
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: -8px;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background-color: var(--Gray10);
+  }
+
+  &:last-of-type::after {
+    display: none;
+  }
+`;
+
+export const Index = styled.p`
+  font: var(--Unselected-Field-rNBLeft);
+  color: var(--Black);
+  width: 20px;
+  text-align: center;
+`;
+
+export const AddButton = styled.button`
+  display: flex;
+  height: 48px;
+  padding: 12px;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  align-self: stretch;
+  border-radius: 8px;
+  background: var(--Primary, #358ffe);
+  color: white;
+  font: var(--Selected-BtnName-FileName);
+  border: none;
+  cursor: pointer;
+`;

--- a/src/styles/invitationWrite/blocks/invitationWriteTimeTableComponent.ts
+++ b/src/styles/invitationWrite/blocks/invitationWriteTimeTableComponent.ts
@@ -1,0 +1,52 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  padding: 20px;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+  border-radius: 8px;
+  background: var(--Gray5, #f4f4f4);
+  box-sizing: border-box;
+  width: 100%;
+
+  > label {
+    color: var(--Black, #151516);
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+    font: var(--Selected-BtnName-FileName);
+  }
+`;
+
+export const InputContainer = styled.div<{ $isSequence: boolean }>`
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+
+  ${({ $isSequence }) =>
+    $isSequence &&
+    `
+      outline: none;
+      border-radius: 4px;
+      border: 2px solid var(--Primary, #358ffe);
+    `}
+`;
+
+export const AddButton = styled.button`
+  display: flex;
+  height: 48px;
+  padding: 12px;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  align-self: stretch;
+  border-radius: 8px;
+  background: var(--Gray40, #88898a);
+  color: white;
+  font: var(--Selected-BtnName-FileName);
+  border: none;
+  cursor: pointer;
+`;

--- a/src/styles/invitationWrite/invitationWriteToolBar.ts
+++ b/src/styles/invitationWrite/invitationWriteToolBar.ts
@@ -18,7 +18,7 @@ export const ToolContainer = styled.div`
   height: 48px;
   padding: 0 20px;
   box-sizing: border-box;
-  justify-content: start;
+  justify-content: space-between;
   align-items: center;
   background-color: var(--Blue5);
   gap: 24px;
@@ -27,6 +27,12 @@ export const ToolContainer = styled.div`
   & > *:first-child {
     margin-right: -12px; /* 원하는 값으로 조정 */
   }
+`;
+
+export const ToolButtonContainer = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: center;
 `;
 
 export const ToolButton = styled.button`
@@ -65,7 +71,6 @@ export const SubToolContainer = styled.div`
 export const ArrowContainer = styled.div`
   display: flex;
   justify-content: end;
-  width: 100%;
   gap: 12px;
 
   > * {

--- a/src/types/invitation.ts
+++ b/src/types/invitation.ts
@@ -13,6 +13,7 @@ export interface Block {
   content?: string;
   image?: string;
   time?: string;
+  colorCode?: number;
 }
 
 interface ScheduleVote {

--- a/src/types/invitation.ts
+++ b/src/types/invitation.ts
@@ -1,7 +1,7 @@
-// interface TimeContent {
-//   time: string;
-//   content: string;
-// }
+export interface TimeTable {
+  time: string;
+  content: string;
+}
 
 export interface Block {
   sequence: number;
@@ -10,7 +10,7 @@ export interface Block {
   color?: string;
   font?: string;
   styles?: string;
-  content?: string;
+  content?: string | TimeTable[];
   image?: string;
   time?: string;
   colorCode?: number;
@@ -56,6 +56,12 @@ export interface InvitationState {
   addImage: (images: File) => void;
   addBlock: (newBlock: Block) => void;
   updateBlock: (sequence: number, updatedProperties: Partial<Block>) => void;
+  updateTimeTable: (sequence: number, index: number, newTime: string) => void;
+  updateTimeTableContent: (
+    sequence: number,
+    index: number,
+    newContent: string
+  ) => void;
 }
 
 export interface InvitationResponse {

--- a/src/types/invitation.ts
+++ b/src/types/invitation.ts
@@ -52,7 +52,7 @@ export interface InvitationState {
   photoImages: File[];
   setInvitation: (update: (draft: Invitation) => void) => void;
   setCardImage: (image: File) => void;
-  setPhotoImages: (images: File[]) => void;
+  addImage: (images: File) => void;
   addBlock: (newBlock: Block) => void;
   updateBlock: (sequence: number, updatedProperties: Partial<Block>) => void;
 }


### PR DESCRIPTION
## 🌏 Summary
<!-- 어떤 내용의 PR인가요? -->

> Fix/#40 작성 qa 수정

## ✨ Work Detail
<!-- 작업 내용을 적어주세요 -->

- [x] 
사진 추가 안됨


박스 추가 안됨


타임테이블 추가 안됨


저장 버튼 클릭 안됨


제목, 일정(투표 추가 시 대체 가능) 두개 다 입력시에만 다음 버튼 활성화하기


편집탭 폰트 스타일 - 세리프 버튼 폰트 적용이 안되어있음

image.png


세리프 폰트에서 볼드 적용이 한번에 안됨, 다른 스타일 적용했다가 다시 클릭해야 보임

텍스트 스타일(볼드,이탤릭,취소선, 밑줄) 적용 후 해제가 안됨 → 한번 더 클릭 시 해당 텍스트의 스타일 적용 취소

요소 삭제 시 오류
구분선 선택 후 삭제 클릭 시 다른 텍스트 필드가 삭제됨
삭제하려는 텍스트 필드 선택 후 삭제 클릭 시 다른 텍스트 필드가 삭제됨
삭제가 아예 안되는 경우(마지막에 남는 요소 또는 랜덤으로 그냥 삭제가 안됨)

카드 선택 버튼 클릭 후 [2] 카드 선택 페이지 갔다오면 [2-1]에서 작성하던 내용 날아감 → 카드 선택 다시 하고 돌아와도 쓰던 내용 남아있도록

## 📚 Comment
<!-- 전달하고 싶은 내용이 있다면 적어주세요 -->

> 
