### PR TITLE
[fix/#34] 초대장 열람, 완성 페이지 QA 수정

### DIFF
--- a/src/components/invitationWrite/CheckComponent.tsx
+++ b/src/components/invitationWrite/CheckComponent.tsx
@@ -5,15 +5,23 @@ import useWMediaQuery from "@/hooks/useWMediaQuery";
 import { usePostInvitation } from "@/hooks/write/usePostInvitation";
 import { TInvitationReq } from "@/types/invite";
 import * as S from "@styles/invite/InvitationDetailPageStyle";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import InvitationWriteHeader from "./InvitationWriteHeader";
 
 type Props = {
   data: TInvitationReq;
   isCheck: boolean;
+  onLeftBtnClick: () => void;
+  onRightBtnClick: () => void;
 };
 
-const CheckComponent = ({ data, isCheck }: Props) => {
+const CheckComponent = ({
+  data,
+  isCheck,
+  onLeftBtnClick,
+  onRightBtnClick,
+}: Props) => {
   const { isMobile } = useWMediaQuery();
   const navigate = useNavigate();
   const { mutate: postInvitation } = usePostInvitation();
@@ -21,10 +29,15 @@ const CheckComponent = ({ data, isCheck }: Props) => {
   //애니메이션 스크롤
   const [scrollY, setScrollY] = useState(0);
   const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+  const [animationStarted, setAnimationStarted] = useState(false);
 
-  const handleScroll = () => {
+  const handleScroll = useCallback(() => {
     setScrollY(window.scrollY);
-  };
+
+    if (window.scrollY === 0 && !animationStarted) {
+      setAnimationStarted(true);
+    }
+  }, [animationStarted]);
 
   const updateScreenWidth = () => {
     setScreenWidth(window.innerWidth);
@@ -40,7 +53,7 @@ const CheckComponent = ({ data, isCheck }: Props) => {
       window.removeEventListener("scroll", handleScroll);
       window.removeEventListener("resize", updateScreenWidth);
     };
-  }, []);
+  }, [handleScroll]);
 
   //완성된 초대장 저장
   const handleSaveInvite = () => {
@@ -77,6 +90,12 @@ const CheckComponent = ({ data, isCheck }: Props) => {
     <S.Container $isHeader={true}>
       {data && (
         <>
+          <InvitationWriteHeader
+            backText="이전"
+            buttonType="저장"
+            onLeftBtnClick={onLeftBtnClick}
+            onRightBtnClick={onRightBtnClick}
+          />
           {isMobile && (
             <S.FadeInImage
               src={
@@ -87,6 +106,8 @@ const CheckComponent = ({ data, isCheck }: Props) => {
               alt="카드 이미지"
               $scrollY={scrollY}
               $screenWidth={screenWidth}
+              $isHeader={true}
+              $animationStarted={animationStarted}
             />
           )}
           <TotheTopBtn />

--- a/src/components/invitationWrite/CheckComponent.tsx
+++ b/src/components/invitationWrite/CheckComponent.tsx
@@ -101,7 +101,7 @@ const CheckComponent = ({
               src={
                 data.cardImage instanceof File
                   ? URL.createObjectURL(data.cardImage)
-                  : (data.cardImage as unknown as string) // SVG 경로 그대로 사용
+                  : (data.cardImage as unknown as string)
               }
               alt="카드 이미지"
               $scrollY={scrollY}

--- a/src/components/invite/CheckContentWrap.tsx
+++ b/src/components/invite/CheckContentWrap.tsx
@@ -54,26 +54,31 @@ const CheckContentWrap = ({ data }: Props) => {
               data={data.invitation.scheduleVotes}
             />
           )}
-          <S.SectionHeader style={{ marginTop: 40 }}>
-            <LocationIcon />
-            <h4>{data.invitation.userLocation || data.invitation.location}</h4>
-          </S.SectionHeader>
-          <a
-            onClick={() => window.open(`${data.invitation.mapLink}`)}
-            style={{ marginBottom: "8px" }}
-          >
-            {data.invitation.address}
-          </a>
-          <LocationMapComponent
-            location={{
-              location: data.invitation.location,
-              address: data.invitation.address,
-              mapLink: data.invitation.mapLink,
-              latitude: data.invitation.latitude,
-              longitude: data.invitation.longitude,
-            }}
-            borderColor={"var(--Gray5)"}
-          />
+          {(data.invitation.userLocation || data.invitation.location) && (
+            <S.SectionHeader style={{ marginTop: 40 }}>
+              <LocationIcon />
+              <h4>
+                {data.invitation.userLocation || data.invitation.location}
+              </h4>
+            </S.SectionHeader>
+          )}
+          {data.invitation.location && (
+            <>
+              <a onClick={() => window.open(`${data.invitation.mapLink}`)}>
+                {data.invitation.address}
+              </a>
+              <LocationMapComponent
+                location={{
+                  location: data.invitation.location,
+                  address: data.invitation.address,
+                  mapLink: data.invitation.mapLink,
+                  latitude: data.invitation.latitude,
+                  longitude: data.invitation.longitude,
+                }}
+                borderColor={"var(--Gray5)"}
+              />
+            </>
+          )}
         </div>
       </S.NotFoldWrap>
       {!isFold && (

--- a/src/components/invite/CheckContentWrap.tsx
+++ b/src/components/invite/CheckContentWrap.tsx
@@ -19,6 +19,7 @@ const CheckContentWrap = ({ data }: Props) => {
   const { isMobile, isTablet, isDesktop } = useWMediaQuery();
 
   const [isFold, setIsFold] = useState(false); //글이 접힌 상태인지 여부
+  let imageIndex = 0;
 
   return (
     <S.CardWrap>
@@ -84,6 +85,9 @@ const CheckContentWrap = ({ data }: Props) => {
       {!isFold && (
         <S.FoldWrap>
           {data.invitation.blocks.map((block) => {
+            if (block.type === "photo") {
+              imageIndex++;
+            }
             return (
               <S.FlodItem key={block.sequence}>
                 {block.type === "divider" && <hr />}
@@ -97,7 +101,10 @@ const CheckContentWrap = ({ data }: Props) => {
                   />
                 )}
                 {block.type === "photo" && (
-                  <img src={block.image!} alt="첨부한 이미지" />
+                  <img
+                    src={URL.createObjectURL(data.photoImages[imageIndex - 1])}
+                    alt="첨부한 이미지"
+                  />
                 )}
                 {block.type === "text" && (
                   <div
@@ -113,6 +120,7 @@ const CheckContentWrap = ({ data }: Props) => {
                           : block.styles === "underline"
                           ? "underline"
                           : "none",
+                      whiteSpace: "pre-wrap",
                     }}
                   >
                     {typeof block.content! === "string" ? block.content : ""}

--- a/src/components/invite/ComingWrap.tsx
+++ b/src/components/invite/ComingWrap.tsx
@@ -24,17 +24,12 @@ const ComingWrap = ({ id, isLogin, isReview }: Props) => {
   const [personName, setPersonName] = useState("");
   const [isCheckPersonName, setIsCheckPersonName] = useState(isLogin);
   const [isAttending, setIsAttending] = useState<boolean | null>(null); //투표자의 참석 여부
-  const [attendanceClosed, setAttendanceClosed] = useState(false); //참석 조사 마감 여부
   const [modalVote, setModalVote] = useState<boolean | null>(null); //선택한 모달
   const [modalData, setModalData] = useState<TAttendanceVotersRes | null>(null); //모달 데이터
 
   useEffect(() => {
-    if (data) {
-      setAttendanceClosed(data.information.attendanceSurveyClosed);
-
-      if (isLogin) {
-        setIsAttending(data.information.isAttending);
-      }
+    if (data && isLogin) {
+      setIsAttending(data.information.isAttending);
     }
   }, [data, isLogin]);
 
@@ -68,7 +63,7 @@ const ComingWrap = ({ id, isLogin, isReview }: Props) => {
       const response = await putAttendance(id);
 
       if (response.check) {
-        setAttendanceClosed(response.information.attendanceSurveyClosed);
+        refetch();
       }
     } catch (error) {
       console.error("오류:", error);
@@ -167,7 +162,7 @@ const ComingWrap = ({ id, isLogin, isReview }: Props) => {
       {data && (
         <S.Container $isReview={isReview}>
           <h3>함께할 수 있는지 알려주세요!</h3>
-          {!isLogin && !attendanceClosed && (
+          {!isLogin && !data.information.attendanceSurveyClosed && (
             <div style={{ width: 348 }}>
               <InputWrap
                 labelText="투표자"
@@ -189,28 +184,34 @@ const ComingWrap = ({ id, isLogin, isReview }: Props) => {
               icon={HappyIcon}
               text="참석 가능해요!"
               count={data.information.attendingCount}
-              isEnd={attendanceClosed}
+              isEnd={data.information.attendanceSurveyClosed}
               isActive={isAttending === true}
               onClick={() =>
-                attendanceClosed ? handleVoter(true) : handleAttendance(true)
+                data.information.attendanceSurveyClosed
+                  ? handleVoter(true)
+                  : handleAttendance(true)
               }
               disabled={
                 !isCheckPersonName ||
-                (attendanceClosed && !data.information.isSender)
+                (data.information.attendanceSurveyClosed &&
+                  !data.information.isSender)
               }
             />
             <AttendanceButton
               icon={SadIcon}
               text="다음에 함께..."
               count={data.information.notAttendingCount}
-              isEnd={attendanceClosed}
+              isEnd={data.information.attendanceSurveyClosed}
               isActive={isAttending === false}
               onClick={() =>
-                attendanceClosed ? handleVoter(false) : handleAttendance(false)
+                data.information.attendanceSurveyClosed
+                  ? handleVoter(false)
+                  : handleAttendance(false)
               }
               disabled={
                 !isCheckPersonName ||
-                (attendanceClosed && !data.information.isSender)
+                (data.information.attendanceSurveyClosed &&
+                  !data.information.isSender)
               }
             />
             {modalVote !== null && modalData && (
@@ -228,7 +229,7 @@ const ComingWrap = ({ id, isLogin, isReview }: Props) => {
               <h3>참석 여부 마감</h3>
               <SlideButton
                 handleState={handleAttendanceClose}
-                currentState={!attendanceClosed}
+                currentState={data.information.attendanceSurveyClosed}
               />
             </S.DeadlineWrap>
           )}

--- a/src/components/invite/ContentWrap.tsx
+++ b/src/components/invite/ContentWrap.tsx
@@ -14,6 +14,7 @@ import ShareWrap from "./ShareWrap";
 import ContentTextBox from "./ContentTextBox";
 import ContentTimeTable from "./ContentTimeTable";
 import KakaoWrap from "./KakaoWrap";
+import LocationMapComponent from "../invitationWrite/location/LocationMapComponent";
 
 interface Props {
   invitationState: number;
@@ -72,12 +73,29 @@ const ContentWrap = ({ invitationState, data, refetch, isDone }: Props) => {
           {data.scheduleVotes.length > 0 && (
             <VoteBox data={data} refetch={refetch} isLogin={data.loggedIn} />
           )}
-          <S.SectionHeader style={{ marginTop: 40 }}>
-            <LocationIcon />
-            <h4>{data.userLocation || data.location}</h4>
-          </S.SectionHeader>
-          <a onClick={() => window.open(`${data.mapLink}`)}>{data.address}</a>
-          <div style={{ color: "red" }}>지도링크</div>
+          {(data.userLocation || data.location) && (
+            <S.SectionHeader style={{ marginTop: 40 }}>
+              <LocationIcon />
+              <h4>{data.userLocation || data.location}</h4>
+            </S.SectionHeader>
+          )}
+          {data.location && (
+            <>
+              <a onClick={() => window.open(`${data.mapLink}`)}>
+                {data.address}
+              </a>
+              <LocationMapComponent
+                location={{
+                  location: data.location,
+                  address: data.address,
+                  mapLink: data.mapLink,
+                  latitude: data.latitude,
+                  longitude: data.longitude,
+                }}
+                borderColor={"var(--Gray5)"}
+              />
+            </>
+          )}
         </div>
       </S.NotFoldWrap>
       {!isFold && (

--- a/src/components/invite/VotePersonModal.tsx
+++ b/src/components/invite/VotePersonModal.tsx
@@ -29,7 +29,7 @@ const VotePersonModal = ({
         return <h4 key={name + index}>{name}</h4>;
       })}
       <hr />
-      <ButtonBottomNext text="완료" color="blue" onClick={onClick} />
+      <ButtonBottomNext text="확인" color="blue" onClick={onClick} />
     </S.ModalWrap>
   );
 };

--- a/src/pages/InvitationDetailPage.tsx
+++ b/src/pages/InvitationDetailPage.tsx
@@ -15,6 +15,7 @@ import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { deleteSentInvite } from "@/api/invitation/deleteSentInvite";
 import { deleteReceivedInvite } from "@/api/invitation/deleteReceivedInvite";
 import TwoBtnModal from "@/components/modal/TwoBtnModal";
+import { ToolBarProvider } from "@/contexts/toolBarContext";
 
 const InvitationDetailPage = () => {
   const { isMobile } = useWMediaQuery();
@@ -107,108 +108,114 @@ const InvitationDetailPage = () => {
   };
 
   return (
-    <S.Container $isHeader={invitationState !== 0}>
-      {data && (
-        <>
-          {invitationState !== 0 && !isDone && (
-            <InvitationWriteHeader
-              backText="이전"
-              buttonType="삭제"
-              onLeftBtnClick={() =>
-                invitationState === 1
-                  ? navigate("/invites/sent")
-                  : navigate("/invites/received")
-              }
-              onRightBtnClick={() =>
-                invitationState === 1
-                  ? setIsDeleteSentModal(true)
-                  : setIsDeleteReceivedModal(true)
-              }
-            />
-          )}
-          {isMobile && (
-            <S.FadeInImage
-              src={data.cardImage}
-              alt="카드 이미지"
-              $scrollY={scrollY}
-              $screenWidth={screenWidth}
-            />
-          )}
-          <TotheTopBtn />
-          <S.BodyWrap $screenWidth={screenWidth}>
+    <ToolBarProvider>
+      <S.Container $isHeader={invitationState !== 0}>
+        {data && (
+          <>
+            {invitationState !== 0 && !isDone && (
+              <InvitationWriteHeader
+                backText="이전"
+                buttonType="삭제"
+                onLeftBtnClick={() =>
+                  invitationState === 1
+                    ? navigate("/invites/sent")
+                    : navigate("/invites/received")
+                }
+                onRightBtnClick={() =>
+                  invitationState === 1
+                    ? setIsDeleteSentModal(true)
+                    : setIsDeleteReceivedModal(true)
+                }
+              />
+            )}
             {isMobile && (
-              <S.Overlay style={{ opacity: Math.max(1 - scrollY / 300, 0) }} />
+              <S.FadeInImage
+                src={data.cardImage}
+                alt="카드 이미지"
+                $scrollY={scrollY}
+                $screenWidth={screenWidth}
+                $isHeader={invitationState !== 0}
+                $animationStarted={true}
+              />
             )}
-            <ContentWrap
-              invitationState={invitationState}
-              data={data}
-              refetch={refetch}
-              isDone={isDone}
-            />
-            {!isDone && (
-              <>
-                {data.attendanceSurveyEnabled && (
-                  <ComingWrap
-                    id={data.invitationId}
-                    isReview={data.canWriteFeedback}
-                    isLogin={data.loggedIn}
-                  />
-                )}
-                {isMobile && invitationState === 0 && (
-                  <SaveWrap
-                    id={data.invitationId}
-                    refetch={refetch}
-                    isLogin={data.loggedIn}
-                  />
-                )}
-                {isMobile && (
-                  <ShareWrap
-                    id={data.invitationId}
-                    title={data.title}
-                    cardImage={data.cardImage}
-                    isAlreadySave={data.alreadySaved}
-                    isLogin={data.loggedIn}
-                    isShareLink={invitationState === 0}
-                    refetch={refetch}
-                  />
-                )}
-                {invitationState !== 0 && data.canWriteFeedback && (
-                  <ReviewWrap
-                    id={data.invitationId}
-                    title={data.title}
-                    isOwner={data.owner}
-                  />
-                )}
-              </>
+            <TotheTopBtn />
+            <S.BodyWrap $screenWidth={screenWidth}>
+              {isMobile && (
+                <S.Overlay
+                  style={{ opacity: Math.max(1 - scrollY / 300, 0) }}
+                />
+              )}
+              <ContentWrap
+                invitationState={invitationState}
+                data={data}
+                refetch={refetch}
+                isDone={isDone}
+              />
+              {!isDone && (
+                <>
+                  {data.attendanceSurveyEnabled && (
+                    <ComingWrap
+                      id={data.invitationId}
+                      isReview={data.canWriteFeedback}
+                      isLogin={data.loggedIn}
+                    />
+                  )}
+                  {isMobile && invitationState === 0 && (
+                    <SaveWrap
+                      id={data.invitationId}
+                      refetch={refetch}
+                      isLogin={data.loggedIn}
+                    />
+                  )}
+                  {isMobile && (
+                    <ShareWrap
+                      id={data.invitationId}
+                      title={data.title}
+                      cardImage={data.cardImage}
+                      isAlreadySave={data.alreadySaved}
+                      isLogin={data.loggedIn}
+                      isShareLink={invitationState === 0}
+                      refetch={refetch}
+                    />
+                  )}
+                  {invitationState !== 0 && data.canWriteFeedback && (
+                    <ReviewWrap
+                      id={data.invitationId}
+                      title={data.title}
+                      isOwner={data.owner}
+                    />
+                  )}
+                </>
+              )}
+            </S.BodyWrap>
+            {isDeleteSentModal && (
+              <TwoBtnModal
+                text="초대장을 삭제하시겠습니까?"
+                leftBtnText="취소"
+                rightBtnText="삭제"
+                color="red"
+                onLeftClick={() => {
+                  setIsDeleteSentModal(false);
+                }}
+                onRightClick={handleDeleteSentInvite}
+              />
             )}
-          </S.BodyWrap>
-          {isDeleteSentModal && (
-            <TwoBtnModal
-              text="초대장을 삭제하시겠습니까?"
-              leftBtnText="취소"
-              rightBtnText="삭제"
-              color="red"
-              onLeftClick={() => {
-                setIsDeleteSentModal(false);
-              }}
-              onRightClick={handleDeleteSentInvite}
-            />
-          )}
-          {isDeleteReceivedModal && (
-            <TwoBtnModal
-              text="초대장을 삭제하시겠습니까?"
-              leftBtnText="취소"
-              rightBtnText="삭제"
-              color="red"
-              onLeftClick={() => {
-                setIsDeleteReceivedModal(false);
-              }}
-              onRightClick={handleDeleteReceivedInvite}
-            />
-          )}
-        </>
-      )}
-    </S.Container>
+            {isDeleteReceivedModal && (
+              <TwoBtnModal
+                text="초대장을 삭제하시겠습니까?"
+                leftBtnText="취소"
+                rightBtnText="삭제"
+                color="red"
+                onLeftClick={() => {
+                  setIsDeleteReceivedModal(false);
+                }}
+                onRightClick={handleDeleteReceivedInvite}
+              />
+            )}
+          </>
+        )}
+      </S.Container>
+    </ToolBarProvider>
   );
 };
 

--- a/src/pages/InvitationWritePage.tsx
+++ b/src/pages/InvitationWritePage.tsx
@@ -77,7 +77,7 @@ const InvitationWritePage = () => {
 
   return (
     <ToolBarProvider>
-      <S.Container>
+      <S.Container $isCheckComponent={isCheckComponent}>
         {!isCheckComponent ? (
           <>
             <InvitationWriteHeader
@@ -101,7 +101,10 @@ const InvitationWritePage = () => {
             <InvitationWriteBottomButton
               isSubmit={isSubmit}
               text={"다음"}
-              onClick={() => setIsCheckComponent(true)}
+              onClick={() => {
+                setIsCheckComponent(true);
+                window.scrollTo({ top: 0, behavior: "smooth" });
+              }}
             />
           </>
         ) : (
@@ -112,6 +115,11 @@ const InvitationWritePage = () => {
               photoImages: photoImages,
             }}
             isCheck={false}
+            onLeftBtnClick={() => {
+              setIsCheckComponent(false);
+              window.scrollTo({ top: 0, behavior: "smooth" });
+            }}
+            onRightBtnClick={handleSave}
           />
         )}
         {isShowModal && <CheckModal exitModal={() => setIsShowModal(false)} />}

--- a/src/styles/Layout.ts
+++ b/src/styles/Layout.ts
@@ -25,5 +25,5 @@ export const HeaderComp = styled.div`
   width: 100%;
   height: 54px;
   border-bottom: 0.125rem solid #f4f4f4;
-  z-index: 10;
+  z-index: 100;
 `;

--- a/src/styles/essentialComponents/top/TopHeaderStyle.ts
+++ b/src/styles/essentialComponents/top/TopHeaderStyle.ts
@@ -11,12 +11,10 @@ export const TopHeader = styled.div`
   background-color: #fcfcfd;
 `;
 
-export const HeaderButtonWithModal  = styled.div`
-
-display: flex;
-align-items: center;
-justify-content: center;
-flex-align: column;
+export const HeaderButtonWithModal = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const HeaderButtonContainer = styled.div`

--- a/src/styles/invitationWrite/invitationWritePage.ts
+++ b/src/styles/invitationWrite/invitationWritePage.ts
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 
-export const Container = styled.div`
+export const Container = styled.div<{ $isCheckComponent: boolean }>`
   display: flex;
   width: 100%;
   flex-direction: column;
-  margin-top: 50px;
+  margin-top: ${(props) => (props.$isCheckComponent ? 0 : 50)}px;
 `;

--- a/src/styles/invite/ContentWrapStyle.ts
+++ b/src/styles/invite/ContentWrapStyle.ts
@@ -90,6 +90,7 @@ export const NotFoldWrap = styled.div<{ $isFold: boolean }>`
   > img {
     transition: all 0.3s ease-in-out;
     width: 100%;
+    object-fit: cover;
 
     ${isTablet} {
       border-radius: 8px;

--- a/src/styles/invite/InvitationDetailPageStyle.ts
+++ b/src/styles/invite/InvitationDetailPageStyle.ts
@@ -1,4 +1,4 @@
-import styled, { keyframes } from "styled-components";
+import styled, { css, keyframes } from "styled-components";
 import { isDesktop, isTablet } from "@/hooks/Media";
 
 export const Container = styled.div<{ $isHeader: boolean }>`
@@ -43,16 +43,23 @@ const fadeIn = keyframes`
 export const FadeInImage = styled.img<{
   $scrollY: number;
   $screenWidth: number;
+  $isHeader: boolean;
+  $animationStarted: boolean;
 }>`
   position: fixed;
-  top: 0;
+  top: ${(props) => (props.$isHeader ? 100 : 52)}px;
   width: 100%;
   height: ${(props) => props.$screenWidth * (3 / 4)};
-  aspect-ratio: 1;
   object-fit: cover;
-  animation: ${fadeIn} 3s ease-out forwards;
   visibility: ${(props) =>
     props.$scrollY > props.$screenWidth * (3 / 4) ? "hidden" : "visible"};
+  opacity: 0;
+
+  ${(props) =>
+    props.$animationStarted &&
+    css`
+      animation: ${fadeIn} 3s ease-out forwards;
+    `}
 `;
 
 export const Overlay = styled.div`

--- a/src/types/invitation.ts
+++ b/src/types/invitation.ts
@@ -11,7 +11,7 @@ export interface Block {
   font?: string;
   styles?: string;
   content?: string | TimeTable[];
-  image?: string;
+  image?: string | File;
   time?: string;
   colorCode?: number;
 }

--- a/src/utils/formatVoteDateTime.ts
+++ b/src/utils/formatVoteDateTime.ts
@@ -20,11 +20,11 @@ export const formatVoteDateTime = (
   const startTime = formatTime(voteStartTime);
   const endTime = formatTime(voteEndTime);
 
-  if (!startTime && !endTime && startDate === endDate) {
-    return startDate;
+  if (endDate) {
+    return `${startDate} ${startTime} ~ ${endDate} ${endTime}`;
   }
 
-  return `${startDate} ${startTime} ~ ${endDate} ${endTime}`;
+  return `${startDate} ${startTime}`;
 };
 
 //시간 포맷팅 함수 (hh:mm AM/PM)


### PR DESCRIPTION
## 🌏 Summary
<!-- 어떤 내용의 PR인가요? -->

> 초대장 열람, 완성 페이지 QA 수정

## ✨ Work Detail
<!-- 작업 내용을 적어주세요 -->

### 초대장 작성 확인 페이지
- [x] 당일 일정 설정 시 물결 표시 제거
- [x] 필드에 첨부한 이미지 안나타나는 문제 수정
- [x] 이전, 저장 헤더 추가

### 열람 페이지
- [x] 보관함 저장 클릭해서 구글 로그인 후 초대장 화면 띄우기
- [x] 로그인 상태일 때 보관함에 저장 안되는 문제 수정
- [x] 프로필 모달 클릭 시 z-index 문제 수정
- [x] 투표자 명단 모달 '완료' 버튼 텍스트 '확인'으로 수정
- [x] 참석여부조사 토글 반대로 켜지는 오류 수정
- [x] 장소 추가 시 주소 표시 부분 수정